### PR TITLE
Fixed alignment and styling for color-box dropdown

### DIFF
--- a/client/app/components/color-box.less
+++ b/client/app/components/color-box.less
@@ -1,11 +1,19 @@
+@import '../assets/less/inc/variables';
+
 color-box {
-  height: 16px !important;
-  display: inline-block !important;
-  overflow: hidden !important;
+  vertical-align: text-bottom;
+  display: inline;
+
   span {
     width: 12px !important;
     height: 12px !important;
     display: inline-block !important;
     margin-right: 5px;
+    vertical-align: middle;
+    border: 1px solid rgba(0,0,0,0.1);
   }
+   & ~ span {
+    vertical-align: bottom;
+    color: @input-color;
+   }
 }


### PR DESCRIPTION
- [x] Bug Fix

## Description
* Text and colorbox vertical alignment. (tested on Safari, Chrome and FF)
* Added outline to colorbox so that "white" would be visible. It also looks a bit nicer.
* Fixed text color to @input-color

## Mobile & Desktop Screenshots

Before|After
--------|-------
<img width="245" alt="Screen Shot 2019-06-17 at 11 53 34" src="https://user-images.githubusercontent.com/486954/59591369-90f76e00-90f6-11e9-953e-3874c4b0eaef.png"> |  <img width="245" alt="Screen Shot 2019-06-17 at 11 53 39" src="https://user-images.githubusercontent.com/486954/59591370-90f76e00-90f6-11e9-80b2-c4481971542c.png">
<img width="239" alt="Screen Shot 2019-06-17 at 11 52 17" src="https://user-images.githubusercontent.com/486954/59591256-63aac000-90f6-11e9-8b5d-1d9176f0495b.png"> | <img width="239" alt="Screen Shot 2019-06-17 at 11 51 28" src="https://user-images.githubusercontent.com/486954/59591257-63aac000-90f6-11e9-9675-62da1f0f0ebd.png">

